### PR TITLE
Support for emptying out buckets that contain more than 1,000 objects.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [1.0.5] 2021-02-26
+
+### Changed
+
+- Emptying out S3 bucket contents now supports buckets that contain more than 1,000 objects.
+
+---
+
 ## [1.0.4] 2020-12-04
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@architect/destroy",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Destroy projects created with Architect",
   "main": "src/index.js",
   "bin": {

--- a/src/_delete-bucket-contents.js
+++ b/src/_delete-bucket-contents.js
@@ -6,33 +6,52 @@ module.exports = function deleteBucketContents ({ bucket }, callback) {
   let region = process.env.AWS_REGION
   let s3 = new aws.S3({ region })
 
-  waterfall([
-    function (callback) {
-      s3.listObjectsV2({ Bucket: bucket }, function done (err, result) {
-        if (err) {
-          callback(err)
-        }
-        else if (result.IsTruncated) {
-          throw Error('bucket has too many objects to delete')
+  let objects = []
+  function collectObjects (ContinuationToken, callback) {
+    s3.listObjectsV2({
+      Bucket: bucket,
+      ContinuationToken
+    }, function done (err, result) {
+      if (err) {
+        callback(err)
+      }
+      else {
+        objects = objects.concat(result.Contents)
+        if (result.IsTruncated) {
+          collectObjects(result.NextContinuationToken, callback)
         }
         else {
-          callback(null, result.Contents.map(item => ({ Key: item.Key })))
+          callback(null, objects.map(item => ({ Key: item.Key })))
         }
-      })
+      }
+    })
+  }
+
+  function deleteObjects (objs, callback) {
+    let batch = objs.splice(0, 1000) // S3.deleteObjects supports up to 1k keys
+    s3.deleteObjects({
+      Bucket: bucket,
+      Delete: {
+        Objects: batch
+      }
+    },
+    function done (err) {
+      if (err) callback(err)
+      else if (objs.length) {
+        deleteObjects(objs, callback)
+      }
+      else callback()
+    })
+  }
+
+  waterfall([
+    function (callback) {
+      collectObjects(null, callback)
     },
 
     function (stuffToDelete, callback) {
       if (Array.isArray(stuffToDelete) && stuffToDelete.length > 0) {
-        s3.deleteObjects({
-          Bucket: bucket,
-          Delete: {
-            Objects: stuffToDelete
-          }
-        },
-        function done (err) {
-          if (err) callback(err)
-          else callback()
-        })
+        deleteObjects(stuffToDelete, callback)
       }
       else {
         callback()


### PR DESCRIPTION
Recursively delete objects from an S3 bucket.

This fixes architect/architect#1077.

I added unit tests for it too but also tested these changes out on a bucket by first creating a shitload of files, then uploading to an S3 bucket:

```
touch file{0000..2001}.log
aws s3 sync . s3://mah-bucket
```

... then I invoked this module from the node CLI (at the time I had more `console.log`s in the code, which I've now removed, but helpful to see how this thing works):

```
deleteBucketContents({bucket:'arc-ws-cfn-deployments-03ddb'}, (err) => { console.log('done, did we get an error?', err) })
calling collect objects
undefined
> now have 1000 objects
recursing on collection
calling collect objects
now have 2000 objects
recursing on collection
calling collect objects
now have 2002 objects
done collecting
deleting 1000 objects
still have 1002 objects
deleting 1000 objects
still have 2 objects
deleting 2 objects
done without errors!
```