### PR TITLE
added a --no-timeout flag

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,18 @@
 
 ---
 
+## [1.3.0] 2021-06-22
+
+### Added
+
+- Added a `--no-timeout` flag, which causes `destroy` to wait until the CloudFormation Stack is deleted before exiting
+
+### Changed
+
+- `destroy` now pings the CloudFormation API to check for Stack deletion every 10 seconds (instead of increasingly backing off starting from 10 seconds to 60 seconds)
+
+---
+
 ## [1.2.4] 2021-06-09
 
 ### Changed

--- a/readme.md
+++ b/readme.md
@@ -6,13 +6,11 @@
 
 [![GitHub CI status](https://github.com/architect/destroy/workflows/Node%20CI/badge.svg)](https://github.com/architect/destroy/actions?query=workflow%3A%22Node+CI%22)
 
-
 Architect Destroy destroys Architect-generated projects. More specifically, it destroys your projects' CloudFormation Stacks, CloudWatch Log Groups, S3 bucket used during deployment, SSM Parameters added by [`arc env`](https://github.com/architect/env), and if called with `--force` (or the `force` param via API), destroys your DynamoDB (`@tables`) databases and S3 bucket housing your static assets (`@static`).
-
 
 ## API
 
-### `destroy({ appname, stackname, env, force, now }, callback)`
+### `destroy({ appname, stackname, env, force, now, retries }, callback)`
 
 Destroys all infrastructure associated to your Architect app.
 
@@ -21,3 +19,7 @@ Destroys all infrastructure associated to your Architect app.
 - `env`: the stage or environment name to destroy, typical values are `staging` or `production`
 - `force` proceeds to destroy your app even if it contains DynamoDB tables and / or an S3 bucket containing `@static` assets.
 - `now`: (boolean) immeditely destroy the app (instead of waiting the requisite 5 seconds)
+- `retries`: while waiting for a CloudFormation Stack to be destroyed, how many
+    times do we ping the CloudFormation API checking if the Stack has been
+    removed? This API is pinged every 10 seconds. If `retries` is exhausted,
+    `callback` will be invoked with an error.

--- a/src/cli.js
+++ b/src/cli.js
@@ -45,6 +45,7 @@ async function main (args) {
     let forces = p => [ '-f', '--force', 'force' ].includes(p)
     let force = args.some(forces)
     let production = args.includes('--production')
+    let retries = args.includes('--no-timeout') ? 999 : 15 // how many times do we ping the CloudFormation API to check if the stack is deleted?
 
     let now = args.includes('--now')
 
@@ -56,7 +57,7 @@ async function main (args) {
     if (env === 'staging') {
       update.status(`Reminder: if you deployed to production, don't forget to run destroy again with: --production`)
     }
-    await destroy({ appname, stackname, env, force, now, update })
+    await destroy({ appname, stackname, env, force, now, retries, update })
   }
   catch (err) {
     let { message } = err


### PR DESCRIPTION
Also exposed number-of-retries as a parameter to the destroy module.

This fixes architect/architect#1157
