### PR TITLE
fix: chunks SSM deletes in groups of max 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@architect/inventory": "~2.0.4",
     "@architect/utils": "~3.0.2",
     "aws-sdk": "2.880.0",
+    "lodash.chunk": "~4.2.0",
     "run-parallel": "~1.2.0",
     "run-waterfall": "~1.1.7"
   },

--- a/test/unit/_ssm-test.js
+++ b/test/unit/_ssm-test.js
@@ -70,7 +70,7 @@ test('deleteAll should handle SSM parameter paths that contain more than 10 para
   t.plan(2)
   let paramsDeleted = []
   aws.mock('SSM', 'deleteParameters', (params, cb) => {
-    paramsDeleted = params.Names
+    paramsDeleted = paramsDeleted.concat(params.Names)
     cb(null, {})
   })
   let appParams = []


### PR DESCRIPTION
When undeploying we were getting the following error on the SSM remove step:

```
ValidationException: 1 validation error detected: Value '[...]' at 'names' failed to satisfy constraint: Member must have length less than or equal to 10.
32
    at Request.extractError 
  [...]
```

This should fix those.