### PR TITLE
Feat: Credentials as parameters

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,9 +2,9 @@
 
 ---
 
-## [Unreleased]
+## [4.1.0] 2024-09-03
 
-### Added
+### Changed
 
 - Added support for `credentials` object parameter in programmatic API
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- Added support for `credentials` object parameter in programmatic API
+
+---
+
 ## [4.0.5] 2024-04-29
 
 ### Changed

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ Architect Destroy destroys Architect-generated projects. More specifically, it d
 
 ## API
 
-### `destroy({ appname, stackname, env, force, now, retries }, callback)`
+### `destroy({ appname, stackname, env, force, now, retries, credentials }, callback)`
 
 Destroys all infrastructure associated to your Architect app.
 
@@ -23,3 +23,4 @@ Destroys all infrastructure associated to your Architect app.
     times do we ping the CloudFormation API checking if the Stack has been
     removed? This API is pinged every 10 seconds. If `retries` is exhausted,
     `callback` will be invoked with an error.
+- `credentials`: (object) AWS credentials object with `accessKeyId`, `secretAccessKey`, and optionally `sessionToken`

--- a/test/unit/credentials-param-test.js
+++ b/test/unit/credentials-param-test.js
@@ -1,0 +1,50 @@
+let test = require('tape')
+let awsLite = require('@aws-lite/client')
+let inventory = require('@architect/inventory')
+let destroy = require('../../')
+
+test('Set up env', async t => {
+  t.plan(1)
+  awsLite.testing.enable()
+  t.ok(awsLite.testing.isEnabled(), 'AWS client testing enabled')
+})
+
+test('destroy credentials accepted', async t => {
+  t.plan(1)
+  let inv = await inventory({
+    rawArc: '@app\ntest-app\n@http\nget /',
+    deployStage: 'staging',
+  })
+  try {
+    await destroy({
+      appname: 'test-app',
+      env: 'staging',
+      credentials: {
+        accessKeyId: 'ASIATEST123456789',
+        secretAccessKey: 'testSecretKey123456789',
+        sessionToken: 'testSessionToken123456789',
+      },
+      inventory: inv,
+      now: true, // Skip the 5-second delay for testing
+    })
+    t.pass('Destroy accepts credentials')
+  }
+  catch (err) {
+    // Check if this is the specific credential rejection error
+    if (err.message.includes('You must supply AWS credentials')) {
+      t.fail('Destroy rejects credentials')
+    }
+    else {
+      // Some other error occurred after credentials were accepted
+      // This is expected since we're not actually destroying real resources
+      t.pass('Destroy accepts credentials')
+    }
+  }
+})
+
+test('Teardown', t => {
+  t.plan(1)
+  awsLite.testing.disable()
+  awsLite.testing.reset()
+  t.notOk(awsLite.testing.isEnabled(), 'AWS client testing disabled')
+})


### PR DESCRIPTION
Adds the ability to use credentials as passed parameters for the direct usage of destroy. 
